### PR TITLE
Update zip-extension.sh in an attempt to avoid the error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/zip-extension.sh
+++ b/zip-extension.sh
@@ -20,6 +20,7 @@ echo "Packaging extension into: $OUTPUT"
 EXCLUDE_PATTERNS=(
   ".git/*"
   ".gitignore"
+  ".gitattributes"
   "*.md"
   "*.zip"
   "zip-extension.sh"


### PR DESCRIPTION
Trying to fix ": invalid option nameine 2: set: pipefail" error when running zi-extension.sh to create the zip

