### PR TITLE
Feature/custom instruction config

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 import BOX from './utils/box.js';
-import { defaultCustomInstructions, CUSTOM_INSTRUCTION_ID } from './settings/config.js';
+import { defaultCustomInstructions } from './settings/config.js';
 import { displayBanner } from './utils/banner.js';
 
 const boxClient = new BOX();
@@ -23,7 +23,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     console.log('Received message in background script:', request);
     if (request.type === "displayBanner" && sender.tab) {
         showBannerInTab(sender.tab.id, request.message, request.bannerType);
-    } else if (request.type === CUSTOM_INSTRUCTION_ID && sender.tab) {
+    } else if (request.type === 'BOX_AI_CUSTOM_INSTRUCTION_PROMPT' && sender.tab) {
         handleBoxAIQuery(
             request.finalFileName,
             request.selectionText,
@@ -43,7 +43,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
             stored.find(i => i.id === info.menuItemId) ||
             defaultCustomInstructions.find(i => i.id === info.menuItemId);
         if (item) {
-            if (item.id === CUSTOM_INSTRUCTION_ID) {
+            if (!item.instruction) {
                 chrome.scripting.executeScript({
                     target: { tabId: tab.id },
                     function: promptForCustomInstructionAndSendMessage,
@@ -240,7 +240,7 @@ function promptForCustomInstructionAndSendMessage(selectionText, finalFileName, 
         return;
     }
     chrome.runtime.sendMessage({
-        type: 'BOX_AI_CUSTOM_INSTRUCTION',
+        type: 'BOX_AI_CUSTOM_INSTRUCTION_PROMPT',
         instruction,
         selectionText,
         finalFileName,

--- a/settings/config.js.example
+++ b/settings/config.js.example
@@ -1,11 +1,10 @@
 export const BOX__CLIENT_ID = "YOUR_CLIENT_ID_HERE"; // Replace with your actual Box client ID
 export const BOX__CLIENT_SECRET = "YOUR_CLIENT_SECRET_HERE"; // Replace with your actual Box client secret
-export const CUSTOM_INSTRUCTION_ID = 'BOX_AI_CUSTOM_INSTRUCTION';
 export const defaultCustomInstructions = [
   {
-    id: CUSTOM_INSTRUCTION_ID,
+    id: 'BOX_AI_CUSTOM_INSTRUCTION',
     title: 'Send custom instruction',
-    instruction: '{Provided upon runtime}',
+    instruction: '',
     sortOrder: 0,
     model: '',
     language: 'en',

--- a/settings/options.html
+++ b/settings/options.html
@@ -67,9 +67,9 @@
   <div class="modal-content">
     <h3 id="modal-title-label">Edit Instruction</h3>
     <label for="modal-title">Title</label>
-    <input id="modal-title" type="text" />
+    <input id="modal-title" type="text" placeholder="Enter a title for this instruction" />
     <label for="modal-instruction">Instruction</label>
-    <textarea id="modal-instruction" rows="8"></textarea>
+    <textarea id="modal-instruction" rows="8" placeholder="Enter the instruction for the AI. Leave blank to be prompted when used."></textarea>
     <label for="modal-model">Model</label>
     <select id="modal-model"></select>
     <label for="modal-language">Language</label>

--- a/settings/options.js
+++ b/settings/options.js
@@ -1,4 +1,4 @@
-import { defaultCustomInstructions, CUSTOM_INSTRUCTION_ID } from './config.js';
+import { defaultCustomInstructions } from './config.js';
 import BOX from '../utils/box.js';
 import { displayBanner } from '../utils/banner.js';
 import '../vendor/box-ui-elements/picker.js';
@@ -252,7 +252,7 @@ function createInstructionRow(item) {
   removeButton.addEventListener('click', () => confirmAndDelete(item));
 
   actionsTd.appendChild(editButton);
-  if (item.id !== CUSTOM_INSTRUCTION_ID) actionsTd.appendChild(removeButton);
+  actionsTd.appendChild(removeButton);
 
   tr.appendChild(enabledTd);
   tr.appendChild(titleTd);


### PR DESCRIPTION
- Modify the logic to trigger the promptForCustomInstructionAndSendMessage function when a custom instruction's instruction field is empty, instead of checking for a specific ID (BOX_AI_CUSTOM_INSTRUCTION)
- Add a placeholder to the instruction textarea in the edit modal to inform users that leaving it blank will prompt for a custom instruction at runtime.

<img width="969" height="921" alt="image" src="https://github.com/user-attachments/assets/f3dd647b-97c4-4e95-9b60-320eedfa0903" />
