### PR TITLE
Improve the error handling to "Login to Box"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Box AI for Chrome",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Ask questions about the selected texts using the Box AI API.",
   "permissions": [
     "storage",

--- a/settings/options.js
+++ b/settings/options.js
@@ -18,6 +18,10 @@ async function loginBoxOAuth() {
     const redirectUri = chrome.identity.getRedirectURL();
     const authUrl = boxClient.getAuthorizeURL(redirectUri);
     chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true }, async (redirectedTo) => {
+        if (chrome.runtime.lastError || !redirectedTo) {
+            console.error(chrome.runtime.lastError);
+            return;
+        }
         const params = new URLSearchParams(new URL(redirectedTo).search);
         const code = params.get('code');
         await boxClient.getTokensAuthorizationCodeGrant(code, redirectUri);


### PR DESCRIPTION
 The loginBoxOAuth function in settings/options.js has a potential issue. It's missing a check for
 chrome.runtime.lastError after the chrome.identity.launchWebAuthFlow call. If the user cancels the login flow,
 chrome.runtime.lastError will be set, and the callback will still be invoked, but redirectedTo will be
 undefined. This can lead to an error when the code tries to access new URL(redirectedTo).search.

This PR adds a check for chrome.runtime.lastError to prevent this error.