### PR TITLE
Fix the failing "Send a custom instruction" functionality

### DIFF
--- a/background.js
+++ b/background.js
@@ -114,7 +114,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
                 chrome.scripting.executeScript({
                     target: { tabId: tab.id },
                     function: promptForCustomInstructionAndSendMessage,
-                    args: [info.selectionText, finalFileName, item.modelConfig, item.targetItems ? JSON.parse(JSON.stringify(item.targetItems)) : null]
+                    args: [info.selectionText, finalFileName, item.modelConfig ? JSON.parse(JSON.stringify(item.modelConfig)) : null, item.targetItems ? JSON.parse(JSON.stringify(item.targetItems)) : null]
                 });
             } else {
                 // Case 2: Pre-defined instruction


### PR DESCRIPTION
The "Send a custom instruction" functionality was failing due to a TypeError: Value is unserializable error. 
Full error message:

> Error handling response: TypeError: Error in invocation of scripting.executeScript(scripting.ScriptInjection injection, optional function callback): Error at parameter 'injection': Error at property 'args': Error at index 2: Value is unserializable. at chrome-extension://jlhabfkcmoinkbkgpkemgjgmppkjigdp/background.js:114:34

This happened when a user-defined custom instruction was selected from the context menu. The root cause was that the modelConfig object, associated with the custom instruction, contained non-serializable data. This object was being passed as an argument to chrome.scripting.executeScript, which requires all its arguments to be serializable in order to pass them from the background script to the content script.

Changes made:

  To resolve this issue, the following change has been implemented in background.js:

   1. Ensure Serializable Arguments: In the chrome.contextMenus.onClicked event listener, before calling
      chrome.scripting.executeScript, I've wrapped the item.modelConfig object with
      JSON.parse(JSON.stringify(item.modelConfig)).

  This technique creates a deep, serializable clone of the modelConfig object. The cloned object is "plain" and does not
  contain any of the complex, non-serializable properties that were causing the error. The same technique was already being
  used for the targetItems object, so I've applied it to modelConfig as well for consistency and correctness.

  This single change ensures that all arguments passed to chrome.scripting.executeScript are serializable, thus fixing the bug
  and allowing the "Send a custom instruction" feature to work as expected.