### PR TITLE
feat: distinguish development and store builds with DEV indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ Before using the extension, you must set up your Box API credentials and authori
 
 ## Development
 - Built with [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/) and plain JavaScript.
+- **Development vs Chrome Web Store builds:** If you install both an unpacked (development) build and the Chrome Web Store build, the extension detects the install type automatically. Unpacked builds lack `update_url` in `manifest.json`; Store builds include it. In development builds only, you will see a **DEV** badge on the toolbar icon, a banner on the Options page, build info in the popup, a small overlay on web pages (`DEV · Box AI v…`), and a **DEV** badge on the chat header. Store builds show version info in the popup but no DEV indicators. See `utils/dev-mode.js` (extension pages and service worker) and `utils/dev-mode-content.js` (content scripts).
 - Key components:
   - `manifest.json`: Extension metadata and permissions.
   - `background.js`: Service worker handling context menus, Box API calls, and messaging.
   - `content.js`: Content script for banners and clipboard operations.
   - `popup/`: Popup UI for opening Options.
   - `settings/`: Options page UI and default configuration.
-  - `utils/`: Shared utility scripts, including the Box API wrapper (`box.js`) and banner notifications (`banner.js`).
+  - `utils/`: Shared utility scripts, including the Box API wrapper (`box.js`), banner notifications (`banner.js`), and dev/store build indicators (`dev-mode.js`, `dev-mode-content.js`).
   - `vendor/`: Third-party libraries like Bootstrap and Box UI Elements.
   - `zip-extension.sh`: Script for creating a ZIP package (for Chrome Web Store upload). Usage: run this at the root of the repository
       ```bash

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Before using the extension, you must set up your Box API credentials and authori
 
 ## Development
 - Built with [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/) and plain JavaScript.
-- **Development vs Chrome Web Store builds:** If you install both an unpacked (development) build and the Chrome Web Store build, the extension detects the install type automatically. Unpacked builds lack `update_url` in `manifest.json`; Store builds include it. In development builds only, you will see a **DEV** badge on the toolbar icon, a banner on the Options page, build info in the popup, a small overlay on web pages (`DEV · Box AI v…`), and a **DEV** badge on the chat header. Store builds show version info in the popup but no DEV indicators. See `utils/dev-mode.js` (extension pages and service worker) and `utils/dev-mode-content.js` (content scripts).
+- **Development vs Chrome Web Store builds:** If you install both an unpacked (development) build and the Chrome Web Store build, the extension detects the install type automatically. Unpacked builds lack `update_url` in `manifest.json`; Store builds include it. In development builds only, you will see a **DEV** badge on the toolbar icon, a banner on the Options page, build info in the popup, a small overlay on web pages (`DEV · Box AI v…`), and a **DEV** badge on the chat header. All builds show the version (`v…`) in the popup, Options page, and toolbar tooltip. See `utils/dev-mode.js` (extension pages and service worker) and `utils/dev-mode-content.js` (content scripts).
 - Key components:
   - `manifest.json`: Extension metadata and permissions.
   - `background.js`: Service worker handling context menus, Box API calls, and messaging.

--- a/background.js
+++ b/background.js
@@ -1,6 +1,9 @@
 import BOX from './utils/box.js';
 import { defaultCustomInstructions } from './settings/config.js';
 import { displayBanner } from './utils/banner.js';
+import { applyToolbarIndicators } from './utils/dev-mode.js';
+
+applyToolbarIndicators();
 
 const TEMP_PREFIX = 'cache_';
 
@@ -329,7 +332,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
             await cleanupTab(tab.id, null);
         }
     });
-});""
+});
 
 
 function promptForCustomInstructionAndSendMessage(selectionText, finalFileName, modelConfig, targetItems) {

--- a/background.js
+++ b/background.js
@@ -354,15 +354,9 @@ function promptForCustomInstructionAndSendMessage(selectionText, finalFileName, 
     });
 }
 
-// When the user clicks on the extension action (toolbar icon).
-chrome.action.onClicked.addListener(async (tab) => {
-  await cleanupTab(tab.id, tab);
-  chrome.tabs.sendMessage(tab.id, { type: "clear_chat" });
-  // Send a message to the active tab to open the chat window.
-  chrome.tabs.sendMessage(tab.id, { type: "open_chat" });
-});
-
 // --- Chat Functionality ---
+// Note: chrome.action.onClicked is not used because default_popup is set in
+// manifest.json; toolbar clicks open the popup instead.
 
 
 async function handleChatMessage(message, tab) {

--- a/background.js
+++ b/background.js
@@ -5,6 +5,10 @@ import { applyToolbarIndicators } from './utils/dev-mode.js';
 
 applyToolbarIndicators();
 
+chrome.runtime.onInstalled.addListener(() => {
+  applyToolbarIndicators();
+});
+
 const TEMP_PREFIX = 'cache_';
 
 const boxClient = new BOX();

--- a/chat/chat.css
+++ b/chat/chat.css
@@ -98,8 +98,10 @@
   background-color: #f1f1f1;
   border-bottom: 1px solid #ccc;
   display: flex;
+  flex-wrap: nowrap;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
   cursor: move;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
@@ -107,6 +109,42 @@
 
 #box-ai-chat-header span {
   font-weight: bold;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#box-ai-chat-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 2px;
+}
+
+#box-ai-chat-header.box-ai-dev-mode-header {
+  background: linear-gradient(90deg, #e67e22, #d35400);
+  color: #fff;
+}
+
+#box-ai-chat-header.box-ai-dev-mode-header span::after {
+  content: "DEV";
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 0.65em;
+  font-weight: bold;
+  line-height: 1.4;
+  vertical-align: middle;
+  white-space: nowrap;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 3px;
+}
+
+#box-ai-chat-header.box-ai-dev-mode-header #box-ai-chat-actions button {
+  color: #fff;
 }
 
 #box-ai-chat-actions button {

--- a/chat/chat.js
+++ b/chat/chat.js
@@ -210,10 +210,6 @@ const setupChatUI = () => {
       case 'receive_chat_message':
         displayMessage(request.message, 'assistant');
         break;
-      case 'open_chat':
-        setMinimized(false); // Maximize
-        chatContainer.style.display = 'flex';
-        break;
       case 'clear_chat':
         messagesContainer.innerHTML = ''; // Clear previous messages
         break;

--- a/chat/chat.js
+++ b/chat/chat.js
@@ -1,5 +1,3 @@
-const { createSvgIcon, icons } = window.BoxExtensionIcons;
-
 /**
  * Creates a "Copy to Clipboard" button for a message.
  * @param {string} message - The text to be copied.
@@ -27,6 +25,13 @@ const createCopyButton = (message) => {
  * Initializes the entire chat UI and its functionalities.
  */
 const setupChatUI = () => {
+  if (!window.BoxExtensionIcons) {
+    setTimeout(setupChatUI, 100);
+    return;
+  }
+
+  const { createSvgIcon, icons } = window.BoxExtensionIcons;
+
   const chatContainer = document.getElementById('box-ai-chat-container');
   if (!chatContainer) {
     setTimeout(setupChatUI, 100); // Retry if the container isn't ready

--- a/content.js
+++ b/content.js
@@ -1,7 +1,12 @@
+import { applyPageOverlay, applyChatHeaderIndicator } from './utils/dev-mode.js';
+
+applyPageOverlay();
+
 // Inject the chat UI
 fetch(chrome.runtime.getURL('chat/chat.html'))
   .then(response => response.text())
   .then(data => {
     // Use insertAdjacentHTML to avoid breaking the page's existing event listeners.
     document.body.insertAdjacentHTML('beforeend', data);
+    applyChatHeaderIndicator();
   });

--- a/content.js
+++ b/content.js
@@ -1,12 +1,8 @@
-import { applyPageOverlay, applyChatHeaderIndicator } from './utils/dev-mode.js';
-
-applyPageOverlay();
-
 // Inject the chat UI
 fetch(chrome.runtime.getURL('chat/chat.html'))
   .then(response => response.text())
   .then(data => {
     // Use insertAdjacentHTML to avoid breaking the page's existing event listeners.
     document.body.insertAdjacentHTML('beforeend', data);
-    applyChatHeaderIndicator();
+    BoxAiDevModeContent.applyChatHeaderIndicator();
   });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Box AI for Chrome",
-  "version": "1.1.6",
+  "version": "1.1.9",
   "description": "Ask questions about the selected texts using the Box AI API.",
   "permissions": [
     "storage",
@@ -38,7 +38,8 @@
     {
       "matches": ["<all_urls>"],
       "css": ["chat/chat.css"],
-      "js": ["utils/icons.js", "content.js", "chat/chat.js"]
+      "js": ["utils/icons.js", "content.js", "chat/chat.js"],
+      "type": "module"
     }
   ],
   "web_accessible_resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -38,8 +38,7 @@
     {
       "matches": ["<all_urls>"],
       "css": ["chat/chat.css"],
-      "js": ["utils/icons.js", "content.js", "chat/chat.js"],
-      "type": "module"
+      "js": ["utils/icons.js", "utils/dev-mode-content.js", "content.js", "chat/chat.js"]
     }
   ],
   "web_accessible_resources": [

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,5 +1,5 @@
 body {
-  width: 200px;
+  width: 240px;
   padding: 10px;
   font-family: sans-serif;
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
+  <div id="build-info"></div>
   <div class="menu">
     <button id="optionsBtn">Options</button>
     <button id="clearCacheBtn">Clear Cache</button>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,3 +1,7 @@
+import { applyPopupUi } from '../utils/dev-mode.js';
+
+applyPopupUi(document.getElementById('build-info'));
+
 function isExtensionContextValid() {
   return typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.id;
 }

--- a/settings/options.js
+++ b/settings/options.js
@@ -1,7 +1,10 @@
 import { defaultCustomInstructions, ALLOWED_DOMAINS } from './config.js';
 import BOX from '../utils/box.js';
 import { displayBanner } from '../utils/banner.js';
+import { applyExtensionPageUi } from '../utils/dev-mode.js';
 import '../vendor/box-ui-elements/picker.js';
+
+applyExtensionPageUi();
 
 // Load available AI models for selection
 let models = [];

--- a/utils/dev-mode-content.js
+++ b/utils/dev-mode-content.js
@@ -1,0 +1,100 @@
+/**
+ * Classic content-script helper for development build indicators.
+ * Kept separate from utils/dev-mode.js (ES module) so content scripts
+ * do not require "type": "module" in manifest.json.
+ */
+const BoxAiDevModeContent = (function() {
+  const STYLE_ID = 'box-ai-dev-mode-styles';
+  const OVERLAY_ID = 'box-ai-dev-mode-overlay';
+  const DEV_COLOR = '#e67e22';
+
+  const isDevelopment = () => !('update_url' in chrome.runtime.getManifest());
+
+  const getInfo = () => {
+    const manifest = chrome.runtime.getManifest();
+    return {
+      version: manifest.version,
+      isDevelopment: isDevelopment(),
+    };
+  };
+
+  const injectStyles = () => {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      .box-ai-dev-mode-overlay {
+        position: fixed;
+        bottom: 8px;
+        right: 8px;
+        z-index: 2147483647;
+        pointer-events: none;
+        background-color: ${DEV_COLOR};
+        color: white;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        font-size: 11px;
+        font-weight: bold;
+        padding: 4px 8px;
+        border-radius: 4px;
+        opacity: 0.92;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      }
+      #box-ai-chat-header.box-ai-dev-mode-header {
+        background: linear-gradient(90deg, ${DEV_COLOR}, #d35400) !important;
+      }
+      #box-ai-chat-header.box-ai-dev-mode-header span::after {
+        content: " [DEV]";
+        font-size: 0.85em;
+        opacity: 0.95;
+      }
+    `;
+    document.head.appendChild(style);
+  };
+
+  const applyPageOverlay = () => {
+    if (!isDevelopment() || window !== window.top) return;
+    if (document.getElementById(OVERLAY_ID)) return;
+
+    const mount = () => {
+      if (document.getElementById(OVERLAY_ID)) return;
+      if (!document.body) return;
+
+      injectStyles();
+      const info = getInfo();
+      const overlay = document.createElement('div');
+      overlay.id = OVERLAY_ID;
+      overlay.className = 'box-ai-dev-mode-overlay';
+      overlay.textContent = `DEV · Box AI v${info.version}`;
+      document.body.appendChild(overlay);
+    };
+
+    if (document.body) {
+      mount();
+    } else {
+      document.addEventListener('DOMContentLoaded', mount, { once: true });
+    }
+  };
+
+  const applyChatHeaderIndicator = () => {
+    if (!isDevelopment()) return;
+
+    const apply = () => {
+      const header = document.getElementById('box-ai-chat-header');
+      if (!header) return false;
+      injectStyles();
+      header.classList.add('box-ai-dev-mode-header');
+      return true;
+    };
+
+    if (apply()) return;
+
+    const observer = new MutationObserver(() => {
+      if (apply()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  };
+
+  applyPageOverlay();
+
+  return { applyChatHeaderIndicator };
+})();

--- a/utils/dev-mode-content.js
+++ b/utils/dev-mode-content.js
@@ -7,6 +7,7 @@ const BoxAiDevModeContent = (function() {
   const STYLE_ID = 'box-ai-dev-mode-styles';
   const OVERLAY_ID = 'box-ai-dev-mode-overlay';
   const DEV_COLOR = '#e67e22';
+  const CHAT_HEADER_WATCH_MS = 30000;
 
   const isDevelopment = () => !('update_url' in chrome.runtime.getManifest());
 
@@ -73,17 +74,34 @@ const BoxAiDevModeContent = (function() {
     const apply = () => {
       const header = document.getElementById('box-ai-chat-header');
       if (!header) return false;
-      injectStyles();
       header.classList.add('box-ai-dev-mode-header');
       return true;
     };
 
     if (apply()) return;
 
+    let timeoutId;
     const observer = new MutationObserver(() => {
-      if (apply()) observer.disconnect();
+      if (apply()) cleanup();
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+
+    const cleanup = () => {
+      observer.disconnect();
+      clearTimeout(timeoutId);
+    };
+
+    timeoutId = setTimeout(cleanup, CHAT_HEADER_WATCH_MS);
+
+    const startObserving = () => {
+      if (!document.body) return;
+      observer.observe(document.body, { childList: true });
+    };
+
+    if (document.body) {
+      startObserving();
+    } else {
+      document.addEventListener('DOMContentLoaded', startObserving, { once: true });
+    }
   };
 
   applyPageOverlay();

--- a/utils/dev-mode-content.js
+++ b/utils/dev-mode-content.js
@@ -39,14 +39,6 @@ const BoxAiDevModeContent = (function() {
         opacity: 0.92;
         box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
       }
-      #box-ai-chat-header.box-ai-dev-mode-header {
-        background: linear-gradient(90deg, ${DEV_COLOR}, #d35400) !important;
-      }
-      #box-ai-chat-header.box-ai-dev-mode-header span::after {
-        content: " [DEV]";
-        font-size: 0.85em;
-        opacity: 0.95;
-      }
     `;
     document.head.appendChild(style);
   };

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -1,12 +1,10 @@
 /**
- * Detects whether this extension is a development (unpacked) or store install,
- * and applies UI indicators accordingly.
+ * Dev/store build detection and UI for extension pages and the service worker.
+ * Content-script indicators (page overlay, chat header) live in dev-mode-content.js.
  */
 const STYLE_ID = 'box-ai-dev-mode-styles';
-const OVERLAY_ID = 'box-ai-dev-mode-overlay';
 const BANNER_ID = 'box-ai-dev-mode-banner';
 const DEV_COLOR = '#e67e22';
-const CHAT_HEADER_WATCH_MS = 30000;
 
 export const isDevelopment = () => !('update_url' in chrome.runtime.getManifest());
 
@@ -49,22 +47,6 @@ const injectStyles = () => {
     }
     html.box-ai-dev-mode body {
       padding-top: calc(20px + 2.1em);
-    }
-    .box-ai-dev-mode-overlay {
-      position: fixed;
-      bottom: 8px;
-      right: 8px;
-      z-index: 2147483647;
-      pointer-events: none;
-      background-color: ${DEV_COLOR};
-      color: white;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      font-size: 11px;
-      font-weight: bold;
-      padding: 4px 8px;
-      border-radius: 4px;
-      opacity: 0.92;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     }
     .box-ai-dev-mode-popup-banner {
       background-color: ${DEV_COLOR};
@@ -145,67 +127,6 @@ export const applyPopupUi = (container) => {
   }
 };
 
-export const applyPageOverlay = () => {
-  if (!isDevelopment() || window !== window.top) return;
-  if (document.getElementById(OVERLAY_ID)) return;
-
-  const mount = () => {
-    if (document.getElementById(OVERLAY_ID)) return;
-    if (!document.body) return;
-
-    injectStyles();
-    const info = getInfo();
-    const overlay = document.createElement('div');
-    overlay.id = OVERLAY_ID;
-    overlay.className = 'box-ai-dev-mode-overlay';
-    overlay.textContent = `DEV · Box AI v${info.version}`;
-    document.body.appendChild(overlay);
-  };
-
-  if (document.body) {
-    mount();
-  } else {
-    document.addEventListener('DOMContentLoaded', mount, { once: true });
-  }
-};
-
-export const applyChatHeaderIndicator = () => {
-  if (!isDevelopment()) return;
-
-  const apply = () => {
-    const header = document.getElementById('box-ai-chat-header');
-    if (!header) return false;
-    injectStyles();
-    header.classList.add('box-ai-dev-mode-header');
-    return true;
-  };
-
-  if (apply()) return;
-
-  let timeoutId;
-  const observer = new MutationObserver(() => {
-    if (apply()) cleanup();
-  });
-
-  const cleanup = () => {
-    observer.disconnect();
-    clearTimeout(timeoutId);
-  };
-
-  timeoutId = setTimeout(cleanup, CHAT_HEADER_WATCH_MS);
-
-  const startObserving = () => {
-    if (!document.body) return;
-    observer.observe(document.body, { childList: true });
-  };
-
-  if (document.body) {
-    startObserving();
-  } else {
-    document.addEventListener('DOMContentLoaded', startObserving, { once: true });
-  }
-};
-
 export const applyToolbarIndicators = () => {
   const info = getInfo();
   chrome.action.setTitle({ title: formatTooltipTitle(info) });
@@ -227,8 +148,6 @@ const BoxAiDevMode = {
   formatTooltipTitle,
   applyExtensionPageUi,
   applyPopupUi,
-  applyPageOverlay,
-  applyChatHeaderIndicator,
   applyToolbarIndicators,
 };
 

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -6,6 +6,7 @@ const STYLE_ID = 'box-ai-dev-mode-styles';
 const OVERLAY_ID = 'box-ai-dev-mode-overlay';
 const BANNER_ID = 'box-ai-dev-mode-banner';
 const DEV_COLOR = '#e67e22';
+const CHAT_HEADER_WATCH_MS = 30000;
 
 export const isDevelopment = () => !('update_url' in chrome.runtime.getManifest());
 
@@ -181,10 +182,28 @@ export const applyChatHeaderIndicator = () => {
 
   if (apply()) return;
 
+  let timeoutId;
   const observer = new MutationObserver(() => {
-    if (apply()) observer.disconnect();
+    if (apply()) cleanup();
   });
-  observer.observe(document.body, { childList: true, subtree: true });
+
+  const cleanup = () => {
+    observer.disconnect();
+    clearTimeout(timeoutId);
+  };
+
+  timeoutId = setTimeout(cleanup, CHAT_HEADER_WATCH_MS);
+
+  const startObserving = () => {
+    if (!document.body) return;
+    observer.observe(document.body, { childList: true });
+  };
+
+  if (document.body) {
+    startObserving();
+  } else {
+    document.addEventListener('DOMContentLoaded', startObserving, { once: true });
+  }
 };
 
 export const applyToolbarIndicators = () => {

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -81,14 +81,6 @@ const injectStyles = () => {
       text-align: center;
       margin-bottom: 10px;
     }
-    #box-ai-chat-header.box-ai-dev-mode-header {
-      background: linear-gradient(90deg, ${DEV_COLOR}, #d35400) !important;
-    }
-    #box-ai-chat-header.box-ai-dev-mode-header span::after {
-      content: " [DEV]";
-      font-size: 0.85em;
-      opacity: 0.95;
-    }
   `;
   document.head.appendChild(style);
 };

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -16,10 +16,16 @@ export const getInfo = () => {
     name: manifest.name,
     version: manifest.version,
     channel: dev ? 'development' : 'store',
-    channelLabel: dev ? 'Development (unpacked)' : 'Chrome Web Store',
     isDevelopment: dev,
   };
 };
+
+export const formatVersion = (info) => `v${info.version}`;
+
+export const formatTooltipTitle = (info) =>
+  info.isDevelopment
+    ? `${info.name} [DEV] · ${formatVersion(info)}`
+    : `${info.name} · ${formatVersion(info)}`;
 
 const injectStyles = () => {
   if (document.getElementById(STYLE_ID)) return;
@@ -75,11 +81,16 @@ const injectStyles = () => {
       font-weight: normal;
       opacity: 0.95;
     }
-    .box-ai-dev-mode-store-info {
+    .box-ai-version-info {
       color: #666;
-      font-size: 11px;
+      font-size: 12px;
       text-align: center;
+    }
+    .box-ai-version-info--popup {
       margin-bottom: 10px;
+    }
+    .box-ai-version-info--options {
+      margin: -20px 0 24px;
     }
   `;
   document.head.appendChild(style);
@@ -89,17 +100,28 @@ export const applyExtensionPageUi = () => {
   const info = getInfo();
   document.documentElement.classList.toggle('box-ai-dev-mode', info.isDevelopment);
 
-  if (!info.isDevelopment) return;
-
   injectStyles();
 
-  if (!document.getElementById(BANNER_ID)) {
-    const banner = document.createElement('div');
-    banner.id = BANNER_ID;
-    banner.className = 'box-ai-dev-mode-banner';
-    banner.textContent = `Development build (unpacked) — v${info.version}`;
-    document.body.insertBefore(banner, document.body.firstChild);
+  if (info.isDevelopment) {
+    if (!document.getElementById(BANNER_ID)) {
+      const banner = document.createElement('div');
+      banner.id = BANNER_ID;
+      banner.className = 'box-ai-dev-mode-banner';
+      banner.textContent = `Development build · ${formatVersion(info)}`;
+      document.body.insertBefore(banner, document.body.firstChild);
+    }
+    return;
   }
+
+  if (document.getElementById('box-ai-version-label')) return;
+  const heading = document.querySelector('.container > h1');
+  if (!heading) return;
+
+  const label = document.createElement('p');
+  label.id = 'box-ai-version-label';
+  label.className = 'box-ai-version-info box-ai-version-info--options';
+  label.textContent = formatVersion(info);
+  heading.insertAdjacentElement('afterend', label);
 };
 
 export const applyPopupUi = (container) => {
@@ -112,14 +134,12 @@ export const applyPopupUi = (container) => {
     container.innerHTML = `
       <div class="box-ai-dev-mode-popup-banner">
         <div class="channel">Development Build</div>
-        <div class="version">v${info.version} · unpacked install</div>
+        <div class="version">${formatVersion(info)}</div>
       </div>
     `;
   } else {
     container.innerHTML = `
-      <div class="box-ai-dev-mode-store-info">
-        Chrome Web Store · v${info.version}
-      </div>
+      <div class="box-ai-version-info box-ai-version-info--popup">${formatVersion(info)}</div>
     `;
   }
 };
@@ -169,21 +189,23 @@ export const applyChatHeaderIndicator = () => {
 
 export const applyToolbarIndicators = () => {
   const info = getInfo();
+  chrome.action.setTitle({ title: formatTooltipTitle(info) });
+
   if (info.isDevelopment) {
     chrome.action.setBadgeText({ text: 'DEV' });
     chrome.action.setBadgeBackgroundColor({ color: DEV_COLOR });
-    chrome.action.setTitle({ title: `${info.name} [DEV] · v${info.version}` });
     console.log('[Box AI for Chrome] Development build (unpacked)');
     console.log(`version: ${info.version}`);
   } else {
     chrome.action.setBadgeText({ text: '' });
-    chrome.action.setTitle({ title: `${info.name} · v${info.version}` });
   }
 };
 
 const BoxAiDevMode = {
   isDevelopment,
   getInfo,
+  formatVersion,
+  formatTooltipTitle,
   applyExtensionPageUi,
   applyPopupUi,
   applyPageOverlay,

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -26,17 +26,22 @@ const injectStyles = () => {
   const style = document.createElement('style');
   style.id = STYLE_ID;
   style.textContent = `
-    html.box-ai-dev-mode body > .container > h1,
-    html.box-ai-dev-mode body > h1 {
-      margin-top: 0;
-    }
     .box-ai-dev-mode-banner {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 999;
+      box-sizing: border-box;
       background-color: ${DEV_COLOR};
       color: white;
       padding: 6px 12px;
       font-size: 0.85em;
       font-weight: bold;
       text-align: center;
+    }
+    html.box-ai-dev-mode body {
+      padding-top: calc(20px + 2.1em);
     }
     .box-ai-dev-mode-overlay {
       position: fixed;

--- a/utils/dev-mode.js
+++ b/utils/dev-mode.js
@@ -1,0 +1,197 @@
+/**
+ * Detects whether this extension is a development (unpacked) or store install,
+ * and applies UI indicators accordingly.
+ */
+const STYLE_ID = 'box-ai-dev-mode-styles';
+const OVERLAY_ID = 'box-ai-dev-mode-overlay';
+const BANNER_ID = 'box-ai-dev-mode-banner';
+const DEV_COLOR = '#e67e22';
+
+export const isDevelopment = () => !('update_url' in chrome.runtime.getManifest());
+
+export const getInfo = () => {
+  const manifest = chrome.runtime.getManifest();
+  const dev = isDevelopment();
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    channel: dev ? 'development' : 'store',
+    channelLabel: dev ? 'Development (unpacked)' : 'Chrome Web Store',
+    isDevelopment: dev,
+  };
+};
+
+const injectStyles = () => {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    html.box-ai-dev-mode body > .container > h1,
+    html.box-ai-dev-mode body > h1 {
+      margin-top: 0;
+    }
+    .box-ai-dev-mode-banner {
+      background-color: ${DEV_COLOR};
+      color: white;
+      padding: 6px 12px;
+      font-size: 0.85em;
+      font-weight: bold;
+      text-align: center;
+    }
+    .box-ai-dev-mode-overlay {
+      position: fixed;
+      bottom: 8px;
+      right: 8px;
+      z-index: 2147483647;
+      pointer-events: none;
+      background-color: ${DEV_COLOR};
+      color: white;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 11px;
+      font-weight: bold;
+      padding: 4px 8px;
+      border-radius: 4px;
+      opacity: 0.92;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    }
+    .box-ai-dev-mode-popup-banner {
+      background-color: ${DEV_COLOR};
+      color: white;
+      padding: 8px 10px;
+      margin: -10px -10px 10px;
+      font-size: 12px;
+      line-height: 1.4;
+      border-radius: 4px 4px 0 0;
+    }
+    .box-ai-dev-mode-popup-banner .channel {
+      font-weight: bold;
+    }
+    .box-ai-dev-mode-popup-banner .version {
+      font-weight: normal;
+      opacity: 0.95;
+    }
+    .box-ai-dev-mode-store-info {
+      color: #666;
+      font-size: 11px;
+      text-align: center;
+      margin-bottom: 10px;
+    }
+    #box-ai-chat-header.box-ai-dev-mode-header {
+      background: linear-gradient(90deg, ${DEV_COLOR}, #d35400) !important;
+    }
+    #box-ai-chat-header.box-ai-dev-mode-header span::after {
+      content: " [DEV]";
+      font-size: 0.85em;
+      opacity: 0.95;
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+export const applyExtensionPageUi = () => {
+  const info = getInfo();
+  document.documentElement.classList.toggle('box-ai-dev-mode', info.isDevelopment);
+
+  if (!info.isDevelopment) return;
+
+  injectStyles();
+
+  if (!document.getElementById(BANNER_ID)) {
+    const banner = document.createElement('div');
+    banner.id = BANNER_ID;
+    banner.className = 'box-ai-dev-mode-banner';
+    banner.textContent = `Development build (unpacked) — v${info.version}`;
+    document.body.insertBefore(banner, document.body.firstChild);
+  }
+};
+
+export const applyPopupUi = (container) => {
+  const info = getInfo();
+  if (!container) return;
+
+  injectStyles();
+
+  if (info.isDevelopment) {
+    container.innerHTML = `
+      <div class="box-ai-dev-mode-popup-banner">
+        <div class="channel">Development Build</div>
+        <div class="version">v${info.version} · unpacked install</div>
+      </div>
+    `;
+  } else {
+    container.innerHTML = `
+      <div class="box-ai-dev-mode-store-info">
+        Chrome Web Store · v${info.version}
+      </div>
+    `;
+  }
+};
+
+export const applyPageOverlay = () => {
+  if (!isDevelopment() || window !== window.top) return;
+  if (document.getElementById(OVERLAY_ID)) return;
+
+  const mount = () => {
+    if (document.getElementById(OVERLAY_ID)) return;
+    if (!document.body) return;
+
+    injectStyles();
+    const info = getInfo();
+    const overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.className = 'box-ai-dev-mode-overlay';
+    overlay.textContent = `DEV · Box AI v${info.version}`;
+    document.body.appendChild(overlay);
+  };
+
+  if (document.body) {
+    mount();
+  } else {
+    document.addEventListener('DOMContentLoaded', mount, { once: true });
+  }
+};
+
+export const applyChatHeaderIndicator = () => {
+  if (!isDevelopment()) return;
+
+  const apply = () => {
+    const header = document.getElementById('box-ai-chat-header');
+    if (!header) return false;
+    injectStyles();
+    header.classList.add('box-ai-dev-mode-header');
+    return true;
+  };
+
+  if (apply()) return;
+
+  const observer = new MutationObserver(() => {
+    if (apply()) observer.disconnect();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+};
+
+export const applyToolbarIndicators = () => {
+  const info = getInfo();
+  if (info.isDevelopment) {
+    chrome.action.setBadgeText({ text: 'DEV' });
+    chrome.action.setBadgeBackgroundColor({ color: DEV_COLOR });
+    chrome.action.setTitle({ title: `${info.name} [DEV] · v${info.version}` });
+    console.log('[Box AI for Chrome] Development build (unpacked)');
+    console.log(`version: ${info.version}`);
+  } else {
+    chrome.action.setBadgeText({ text: '' });
+    chrome.action.setTitle({ title: `${info.name} · v${info.version}` });
+  }
+};
+
+const BoxAiDevMode = {
+  isDevelopment,
+  getInfo,
+  applyExtensionPageUi,
+  applyPopupUi,
+  applyPageOverlay,
+  applyChatHeaderIndicator,
+  applyToolbarIndicators,
+};
+
+export default BoxAiDevMode;


### PR DESCRIPTION
## Summary

- Add dev/store build detection via `update_url` presence in `manifest.json`
- Show DEV indicators in unpacked builds only: toolbar badge, popup banner, fixed Options banner, page overlay, and chat header badge
- Show unified version label (`v{version}`) in popup, Options page, and toolbar tooltip for all builds
- Split content-script helpers into classic `utils/dev-mode-content.js` and ES module `utils/dev-mode.js` (background, popup, options)
- Fix pre-existing service worker syntax error in `background.js` (`});""`)

## Goal

When both an unpacked development build and the Chrome Web Store build are installed, developers can immediately tell which instance is active across toolbar, extension UI, and web pages.

## Implementation details

- **Detection**: `!('update_url' in chrome.runtime.getManifest())` → development build
- **Toolbar**: `DEV` badge + tooltip via `applyToolbarIndicators()` on SW startup and `chrome.runtime.onInstalled`
- **Popup / Options**: version display for all builds; DEV banner for development builds only
- **Content scripts**: classic script load order — `icons.js` → `dev-mode-content.js` → `content.js` → `chat/chat.js`
- **Chat header**: compact `DEV` pill badge; flex layout prevents header wrapping
- **Observer cleanup**: chat header watcher disconnects after 30s or on success

## Testing

Manual testing recommended:

- [x] Unpacked build: DEV badge, popup/options version, page overlay, chat header
- [x] Gmail: context menu → Box AI → chat window displays (fixed classic-script regression)
- [ ] Simulated store build (`update_url` in manifest): no DEV indicators, version only
- [ ] Options page: DEV banner fixed at top while scrolling
- [ ] Extension reload/update: toolbar indicators refresh correctly

## Known limitations / follow-ups
- Dev overlay may overlap chat widget in bottom-right corner during development